### PR TITLE
pddocs Vanilla - netreceive to noise~

### DIFF
--- a/Resources/pddoc/vanilla/netreceive.pddoc
+++ b/Resources/pddoc/vanilla/netreceive.pddoc
@@ -6,7 +6,7 @@
             <authors>
                 <author>Miller Smith Puckette</author>
             </authors>
-            <description>receive messages from the network</description>
+            <description>Receive messages from network</description>
             <license>BSD</license>
             <library>puredata</library>
             <category>misc</category>
@@ -17,7 +17,8 @@
             <par>-</par>
         </info>
         <arguments>
-            <argument name="ARG_NAME" type="symbol">-</argument>
+            <argument name="Port number" type="float">-</argument>
+            <argument name="UDP hostname or multicast address" type="symbol">-</argument>
         </arguments>
         <methods>
             <method name="NAME">
@@ -25,13 +26,15 @@
         </methods>
         <inlets>
             <inlet>
-                <xinfo on="bang">output value</xinfo>
-                <xinfo on="float">-</xinfo>
-                <xinfo on="symbol">-</xinfo>
+                <xinfo on="listen [float, symbol]">Set the port number</xinfo>
+                <xinfo on="send [anything]">Sends messages back to connected netsend objects</xinfo>
+                <xinfo on="list">Works like 'send'</xinfo>
             </inlet>
         </inlets>
         <outlets>
-            <outlet>output</outlet>
+            <outlet>Messages sent from connected netsend objects</outlet>
+            <outlet>Number of open connections for TCP connections</outlet>
+            <outlet>Address and port</outlet>
         </outlets>
         <example>
             <pdascii>

--- a/Resources/pddoc/vanilla/netsend.pddoc
+++ b/Resources/pddoc/vanilla/netsend.pddoc
@@ -6,7 +6,7 @@
             <authors>
                 <author>Miller Smith Puckette</author>
             </authors>
-            <description>send messages over the network</description>
+            <description>Send messages over the network</description>
             <license>BSD</license>
             <library>puredata</library>
             <category>misc</category>
@@ -17,7 +17,6 @@
             <par>-</par>
         </info>
         <arguments>
-            <argument name="ARG_NAME" type="symbol">-</argument>
         </arguments>
         <methods>
             <method name="NAME">
@@ -25,13 +24,16 @@
         </methods>
         <inlets>
             <inlet>
-                <xinfo on="bang">output value</xinfo>
-                <xinfo on="float">-</xinfo>
-                <xinfo on="symbol">-</xinfo>
+                <xinfo on="connect [list]">Sets host and port number</xinfo>
+                <xinfo on="disconnect">Close the connection</xinfo>
+                <xinfo on="timeout [float]">TCP connect timeout in ms</xinfo>
+                <xinfo on="send [anything]">Sends messages over the network</xinfo>\
+                <xinfo on="list">Works like 'send'</xinfo>
             </inlet>
         </inlets>
         <outlets>
-            <outlet>output</outlet>
+            <outlet>Nonzero if connection is open, zero otherwise</outlet>
+            <outlet>Messages sent back from netreceive objects</outlet>
         </outlets>
         <example>
             <pdascii>

--- a/Resources/pddoc/vanilla/noise~.pddoc
+++ b/Resources/pddoc/vanilla/noise~.pddoc
@@ -6,7 +6,7 @@
             <authors>
                 <author>Miller Smith Puckette</author>
             </authors>
-            <description>white noise generator</description>
+            <description>White noise generator</description>
             <license>BSD</license>
             <library>puredata</library>
             <category>audio filters</category>
@@ -17,21 +17,16 @@
             <par>-</par>
         </info>
         <arguments>
-            <argument name="ARG_NAME" type="symbol">-</argument>
         </arguments>
         <methods>
-            <method name="NAME">
-            <param type="float" name="V" required="true">-</param></method>
         </methods>
         <inlets>
             <inlet>
-                <xinfo on="bang">output value</xinfo>
-                <xinfo on="float">-</xinfo>
-                <xinfo on="symbol">-</xinfo>
+                <xinfo on="seed [float]">Set seed</xinfo>
             </inlet>
         </inlets>
         <outlets>
-            <outlet>output</outlet>
+            <outlet>Signal</outlet>
         </outlets>
         <example>
             <pdascii>


### PR DESCRIPTION
Hi!

- I'm just trying a pull request with 3 objects, to test the workflow. Is everything ok like this?

- I don't have any object called neq in vanilla 0.52.2. 
Is is from else or cyclone?

- For inlets, I decided to shorten at maximum as well:
For the inlet of Netreceive, i'd keep only: _Set the port number_

in pd reference, it says:
_a number sets or changes the port number (0 or negative closes the port). Optional symbol is a hostname which can be a UDP multicast address or a network interface._

My point is: when I hover an inlet, I want the most basic info, only a basic clue. 
If I want more details, I click help and pd reference!
