### PR TITLE
Use attributedString to allow font fallbacks in object text

### DIFF
--- a/Source/Objects/CommentObject.h
+++ b/Source/Objects/CommentObject.h
@@ -17,8 +17,14 @@ struct CommentObject final : public TextBase
         g.setFont(font);
 
         if (!editor) {
+            TextLayout textLayout;
             auto textArea = border.subtractedFrom(getLocalBounds());
-            g.drawFittedText(currentText, textArea, justification, numLines, minimumHorizontalScale);
+            AttributedString attributedCurrentText(currentText);
+            attributedCurrentText.setColour(findColour(PlugDataColour::textColourId));
+            attributedCurrentText.setFont(font);
+            attributedCurrentText.setJustification(justification);
+            textLayout.createLayout(attributedCurrentText, textArea.getWidth());
+            textLayout.draw(g, textArea.toFloat());
 
             auto selected = cnv->isSelected(object);
             if (object->locked == var(false) && (object->isMouseOverOrDragging(true) || selected) && !cnv->isGraph) {

--- a/Source/Objects/TextObject.h
+++ b/Source/Objects/TextObject.h
@@ -50,11 +50,14 @@ struct TextBase : public ObjectBase
         g.setColour(object->findColour(PlugDataColour::canvasColourId));
         g.fillRoundedRectangle(getLocalBounds().toFloat().reduced(0.5f), 2.0f);
 
-        g.setColour(findColour(PlugDataColour::textColourId));
-        g.setFont(font);
-
+        TextLayout textLayout;
         auto textArea = border.subtractedFrom(getLocalBounds());
-        g.drawFittedText(currentText, textArea, justification, numLines, minimumHorizontalScale);
+        AttributedString attributedCurrentText(currentText);
+        attributedCurrentText.setColour(findColour(PlugDataColour::textColourId));
+        attributedCurrentText.setFont(font);
+        attributedCurrentText.setJustification(justification);
+        textLayout.createLayout(attributedCurrentText, textArea.getWidth());
+        textLayout.draw(g, textArea.toFloat());
 
         bool selected = cnv->isSelected(object);
 


### PR DESCRIPTION
so, JUCE [doesn't support font fallback by default](https://forum.juce.com/t/texteditor-bold-italic-glyph-fallback-font-support-on-macos/43194), which is why **hatitrain** was getting blank comments when trying to view a patch with Korean text (see #184)

this fixes that in Object and Comment when not in edit mode by using `attributedString` which _does_ work. 

for full support:
- the `TextEditor` class's `drawContent` will probably need to be overridden to use `attributedString` for drawing its text
- the tabs and labels will need to use `attributedString` too

✨  note:

i've seen some people say this doesn't work on Windows without disabling directwrite (`#define JUCE_USE_DIRECTWRITE 0`) so worth checking this build out on a windows machine to see if that's necessary