### PR TITLE
alt + drag fix

### DIFF
--- a/Source/Canvas.h
+++ b/Source/Canvas.h
@@ -152,6 +152,7 @@ class Canvas : public Component, public Value::Listener, public LassoSource<Weak
     pd::Storage storage;
     
     Point<int> lastMousePosition;
+    std::vector<Point<int>> mouseDownObjectPositions; // Stores object positions for alt + drag
 
    private:
     


### PR DESCRIPTION
now positions correctly while dragging. And only creates a single undo action for duplication + drag.