### PR TITLE
fix TextEditorDialog scaling

### DIFF
--- a/Source/Dialogs/Dialogs.cpp
+++ b/Source/Dialogs/Dialogs.cpp
@@ -91,12 +91,12 @@ bool Dialog::wantsRoundedCorners() const
     return true;
 }
 
-Component* Dialogs::showTextEditorDialog(String const& text, String filename, std::function<void(String, bool)> closeCallback, std::function<void(String)> saveCallback, bool const enableSyntaxHighlighting)
+Component* Dialogs::showTextEditorDialog(String const& text, String filename, std::function<void(String, bool)> closeCallback, std::function<void(String)> saveCallback, const float desktopScale, bool const enableSyntaxHighlighting)
 {
 #if ENABLE_TESTING
     return nullptr;
 #endif
-    auto* editor = new TextEditorDialog(std::move(filename), enableSyntaxHighlighting, std::move(closeCallback), std::move(saveCallback));
+    auto* editor = new TextEditorDialog(std::move(filename), enableSyntaxHighlighting, std::move(closeCallback), std::move(saveCallback), desktopScale);
     editor->editor.setText(text);
     return editor;
 }

--- a/Source/Dialogs/Dialogs.h
+++ b/Source/Dialogs/Dialogs.h
@@ -161,7 +161,7 @@ public:
 };
 
 struct Dialogs {
-    static Component* showTextEditorDialog(String const& text, String filename, std::function<void(String, bool)> closeCallback, std::function<void(String)> saveCallback, bool enableSyntaxHighlighting = false);
+    static Component* showTextEditorDialog(String const& text, String filename, std::function<void(String, bool)> closeCallback, std::function<void(String)> saveCallback, float desktopScale = 1.0f, bool enableSyntaxHighlighting = false);
     static void appendTextToTextEditorDialog(Component* dialog, String const& text);
     static void clearTextEditorDialog(Component* dialog);
     

--- a/Source/Dialogs/TextEditorDialog.h
+++ b/Source/Dialogs/TextEditorDialog.h
@@ -2897,12 +2897,13 @@ struct TextEditorDialog final : public Component
     String title;
     int margin;
 
-    explicit TextEditorDialog(String name, bool const enableSyntaxHighlighting, std::function<void(String, bool)> const& closeCallback, std::function<void(String)> const& saveCallback)
+    explicit TextEditorDialog(String name, bool const enableSyntaxHighlighting, std::function<void(String, bool)> const& closeCallback, std::function<void(String)> const& saveCallback, const float scale)
         : resizer(this, &constrainer)
         , onClose(closeCallback)
         , onSave(saveCallback)
         , title(std::move(name))
         , margin(ProjectInfo::canUseSemiTransparentWindows() ? 15 : 0)
+        , desktopScale(scale)
     {
         closeButton.reset(LookAndFeel::getDefaultLookAndFeel().createDocumentWindowButton(-1));
         addAndMakeVisible(closeButton.get());
@@ -2923,7 +2924,7 @@ struct TextEditorDialog final : public Component
         setVisible(true);
 
         // Position in centre of screen
-        setBounds(Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea.withSizeKeepingCentre(700, 500));
+        setBounds((Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea / desktopScale).withSizeKeepingCentre(700, 500));
 
         addAndMakeVisible(saveButton);
         addAndMakeVisible(undoButton);
@@ -3067,4 +3068,8 @@ struct TextEditorDialog final : public Component
             Fonts::drawText(g, title, b.getX(), b.getY(), b.getWidth(), 40, findColour(PlugDataColour::toolbarTextColourId), 15, Justification::centred);
         }
     }
+
+    float getDesktopScaleFactor() const override { return desktopScale * Desktop::getInstance().getGlobalScaleFactor(); }
+private:
+    float desktopScale = 1.0f;
 };

--- a/Source/Objects/LuaObject.h
+++ b/Source/Objects/LuaObject.h
@@ -625,7 +625,8 @@ public:
             sendRepaintMessage();
         };
 
-        textEditor.reset(Dialogs::showTextEditorDialog(fileToOpen.loadFileAsString(), "lua: " + getText(), onClose, onSave, true));
+        const auto scaleFactor = getApproximateScaleFactorForComponent(cnv->editor);
+        textEditor.reset(Dialogs::showTextEditorDialog(fileToOpen.loadFileAsString(), "lua: " + getText(), onClose, onSave, scaleFactor, true));
 
         if (textEditor)
             cnv->editor->openTextEditors.add_unique(ptr);
@@ -738,7 +739,8 @@ public:
             }
         };
 
-        textEditor.reset(Dialogs::showTextEditorDialog(fileToOpen.loadFileAsString(), "lua: " + getText(), onClose, onSave, true));
+        const auto scaleFactor = getApproximateScaleFactorForComponent(cnv->editor);
+        textEditor.reset(Dialogs::showTextEditorDialog(fileToOpen.loadFileAsString(), "lua: " + getText(), onClose, onSave, scaleFactor, true));
 
         if (textEditor)
             cnv->editor->openTextEditors.add_unique(ptr);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1716,7 +1716,9 @@ void PluginProcessor::showTextEditorDialog(uint64_t ptr, SmallString const& titl
                 save(lastText, ptr);
             }
         };
-        if(auto* textEditor = Dialogs::showTextEditorDialog("", title.toString(), onClose, onSave)) {
+
+        const auto scaleFactor = getActiveEditor() ? Component::getApproximateScaleFactorForComponent(getActiveEditor()) : 1.0f;
+        if(auto* textEditor = Dialogs::showTextEditorDialog("", title.toString(), onClose, onSave, scaleFactor)) {
             textEditorDialogs[ptr].reset(textEditor);
         }
     });


### PR DESCRIPTION
Basically copying the methods from JUCE DialogWindow here. Should be good to go! I did swap the argument order so that the syntax highlighting option stays at the end. I did that because the scaling factor would always have to be explicitly defined, while syntax highlighting could be left as default.