### PR TITLE
Windows: enable third-party Pd externals in VST3/CLAP/LV2 plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,6 +750,23 @@ if(APPLE)
 endif()
 endif()
 
+# On MSVC, pd-multi is a SHARED library (pd.dll) so third-party externals can resolve pd.dll imports.
+# Embed a SxS manifest declaring pd.dll as a private assembly file, so the Windows loader
+# searches the plugin's own directory (not just the DAW's exe directory) for pd.dll.
+if(MSVC)
+    set(PD_DLL_MANIFEST "${CMAKE_CURRENT_SOURCE_DIR}/Resources/pd.dll.manifest")
+    foreach(_fmt VST3 CLAP LV2)
+        foreach(_tgt plugdata_${_fmt} plugdata_fx_${_fmt})
+            target_link_options(${_tgt} PRIVATE "/MANIFEST:EMBED" "/MANIFESTINPUT:${PD_DLL_MANIFEST}")
+            add_custom_command(TARGET ${_tgt} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "$<TARGET_FILE:pd-multi>"
+                "$<TARGET_FILE_DIR:${_tgt}>/pd.dll"
+            )
+        endforeach()
+    endforeach()
+endif()
+
 target_include_directories(plugdata_core PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/BinaryData)
 
 target_include_directories(plugdata_standalone PUBLIC ${PLUGDATA_INCLUDE_DIRECTORY})
@@ -906,6 +923,7 @@ elseif(WIN32)
   install(DIRECTORY ${PLUGDATA_PLUGINS_LOCATION}/LV2/plugdata-fx.lv2 DESTINATION "$ENV{PROGRAMFILES}/Common Files/LV2")
   install(FILES ${PLUGDATA_PLUGINS_LOCATION}/CLAP/plugdata.clap DESTINATION "$ENV{PROGRAMFILES}/Common Files/CLAP")
   install(FILES ${PLUGDATA_PLUGINS_LOCATION}/CLAP/plugdata-fx.clap DESTINATION "$ENV{PROGRAMFILES}/Common Files/CLAP")
+  install(FILES ${PLUGDATA_PLUGINS_LOCATION}/CLAP/pd.dll DESTINATION "$ENV{PROGRAMFILES}/Common Files/CLAP")
   install(PROGRAMS ${PLUGDATA_PLUGINS_LOCATION}/Standalone/plugdata.exe DESTINATION "$ENV{PROGRAMFILES}/plugdata/")
   install(PROGRAMS ${PLUGDATA_PLUGINS_LOCATION}/Standalone/pd.dll DESTINATION "$ENV{PROGRAMFILES}/plugdata/")
 elseif(UNIX AND NOT APPLE) # Linux or BSD

--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -495,7 +495,10 @@ add_library(pd-src-multi STATIC ${SOURCE_FILES})
 target_compile_definitions(pd-src-multi PRIVATE ${LIBPD_COMPILE_DEFINITIONS} PDINSTANCE=1 PDTHREADS=1)
 
 if(MSVC)
-    target_compile_definitions(pd-src-multi PRIVATE PTW32_STATIC_LIB=1 "EXTERN= ")
+    target_compile_definitions(pd-src-multi PRIVATE PTW32_STATIC_LIB=1 VST_CLEANSER=1)
+    # Provide global symbol stubs (s_bang, s_float, etc.) and vst_cleanser()
+    # so third-party externals compiled against vanilla Pd can link and run.
+    target_sources(pd-src-multi PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/pure-data/src/pd_compat_globals.c)
 endif()
 
 set_target_properties(externals-multi PROPERTIES C_VISIBILITY_PRESET hidden)
@@ -542,7 +545,14 @@ if("${CMAKE_SYSTEM}" MATCHES "Linux")
     target_link_libraries(externals-multi PUBLIC ${externals_libs} ${GEM_LIBS_MULTI} lua-multi)
 elseif(MSVC)
     add_library(pd SHARED $<TARGET_OBJECTS:externals> $<TARGET_OBJECTS:pd-src>)
-    add_library(pd-multi STATIC $<TARGET_OBJECTS:externals-multi> $<TARGET_OBJECTS:pd-src-multi>)
+    add_library(pd-multi SHARED $<TARGET_OBJECTS:externals-multi> $<TARGET_OBJECTS:pd-src-multi>)
+    # Output as pd.dll so third-party externals (which import from pd.dll) can resolve symbols.
+    # Use separate output directories to avoid collision with the standalone pd target.
+    set_target_properties(pd-multi PROPERTIES
+        OUTPUT_NAME "pd"
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pd-multi"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pd-multi"
+    )
 
     target_link_libraries(pd PUBLIC pthreadVC3 ws2_32 ${externals_libs} ${GEM_LIBS} lua)
     target_link_libraries(pd-multi PUBLIC pthreadVC3 ws2_32 ${externals_libs} ${GEM_LIBS_MULTI} lua-multi)

--- a/Resources/pd.dll.manifest
+++ b/Resources/pd.dll.manifest
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <file name="pd.dll"/>
+</assembly>

--- a/Source/Pd/Setup.cpp
+++ b/Source/Pd/Setup.cpp
@@ -18,6 +18,40 @@ extern "C" {
 #include <cstring>
 #include "Setup.h"
 
+#ifdef _WIN32
+#include <windows.h>
+// Ensure pd.dll's directory is in the DLL search path so that third-party
+// externals loaded via LoadLibrary in s_loader.c can resolve their pd.dll
+// dependency. The VST3's SxS manifest only helps the plugin itself find
+// pd.dll, not dynamically-loaded externals.
+static void addPdDllDirToPath()
+{
+    HMODULE pdModule = nullptr;
+    if (!GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            (LPCSTR)&pd_typedmess, &pdModule) || !pdModule)
+        return;
+
+    char pdPath[MAX_PATH];
+    DWORD len = GetModuleFileNameA(pdModule, pdPath, MAX_PATH);
+    if (len == 0 || len >= MAX_PATH)
+        return;
+
+    // Extract directory from full path
+    char* lastSlash = strrchr(pdPath, '\\');
+    if (!lastSlash)
+        return;
+    *lastSlash = '\0';
+
+    // Prepend pd.dll's directory to PATH
+    char oldPath[32768] = {};
+    GetEnvironmentVariableA("PATH", oldPath, sizeof(oldPath));
+    char newPath[32768];
+    snprintf(newPath, sizeof(newPath), "%s;%s", pdPath, oldPath);
+    SetEnvironmentVariableA("PATH", newPath);
+}
+#endif
+
 #if ENABLE_GEM
 #include <Gem/src/Output/gemjucewindow.h>
 #endif
@@ -1335,6 +1369,9 @@ int Setup::initialisePd()
 {
     static int initialized = 0;
     if (!initialized) {
+#ifdef _WIN32
+        addPdDllDirToPath();
+#endif
         libpd_set_printhook(plugdata_print);
 
         // Initialise pd


### PR DESCRIPTION
# Summary
This PR addresses a critical issue where third-party externals fail to load in the plugdata VST3 plugin. This is caused by missing symbols and the absence of a standalone `pd.dll` at runtime. By transitioning `pd-multi` to a shared library and implementing an ABI compatibility layer, this change enables support for complex externals while maintaining multi-instance stability.

---

## Problem: Missing pd.dll and ABI Incompatibility
Previously, `plugdata` VST3 statically linked `pd-multi`, which meant no `pd.dll` was present at runtime. This resulted in two primary failures:

1.  **Error 126 (Module Not Found):** Externals attempting to import symbols from `pd.dll` failed because the file did not exist in the search path.
2.  **Error 127 (Proc Not Found):** With `PDINSTANCE=1` enabled, pre-defined symbols (such as `s_bang`, `s_list`) become per-instance macros. Third-party externals expecting these as global exported symbols failed to resolve them.

---

## Solution: A Three-Layered Approach

### 1. Build Architecture Shift
* **Shared Library:** Changed `pd-multi` from a `STATIC` to a `SHARED` library (`pd.dll`) in `Libraries/CMakeLists.txt`.
* **Export Configuration:** Removed the `EXTERN= ` override to allow `dllexport` to function correctly.
* **Compatibility:** Set `OUTPUT_NAME` to `pd` to ensure import table compatibility with standard Pd externals.

### 2. DLL Search Path Mechanisms
* **SxS Manifest:** Embedded a Side-by-Side manifest (`<file name="pd.dll"/>`) into the plugin DLLs via `/MANIFEST:EMBED`. This ensures the Windows loader finds `pd.dll` in the plugin's own directory during DAW scanning.
* **Environment Path Injection:** In `Setup.cpp`, the directory containing `pd.dll` is prepended to the process `PATH` at initialization. This ensures that `s_loader.c`'s `LoadLibrary` calls can resolve `pd.dll` for third-party externals, as SxS manifests do not propagate to dynamically loaded DLLs.

### 3. ABI Compatibility via VST_CLEANSER
* **Upstream Alignment:** Enabled `VST_CLEANSER=1` for `pd-src-multi`.
* **Global Symbol Stubs:** Introduced `pd_compat_globals.c`, which exports 12 global `t_symbol` stubs and implements `vst_cleanser()` to translate stale global pointers to their per-instance equivalents at Pd API entry points.
* **Extended Coverage:** Expanded the cleanser's reach to include `outlet_new()` and `inlet_new()` in `m_obj.c` (upstream originally only covered `pd_bind`, `pd_unbind`, `pd_symbol`, `pd_list`, `pd_anything`, and `class_doaddmethod`).

---

## Testing & Verification
* **Hosts:** Successfully recognized and tested in **FL Studio** and **Ableton Live**.
* **Externals:** Verified that **FluCoMa** and other third-party externals load and function correctly.
* **Stability:** Multi-instance functionality remains intact and stable.

---

---

## Note for Reviewers
> [!TIP]
> **Technical Implementation & Reference**
> This PR addresses complex low-level issues regarding DLL linking, SxS manifests, and ABI translation. While I utilized LLM assistance to facilitate parts of the implementation, I have **manually audited and refined the code** through local debugging in various DAWs. 
> 
> Even if certain implementation details require further adjustment to meet the project's exact standards, I believe the three-layered approach used here (SxS manifests, `VST_CLEANSER` extensions, and path injection) provides a **viable roadmap and a useful reference** for resolving these symbol resolution issues in `plugdata`.
> 
> Given the sensitivity of cross-module linking on Windows, I suggest a close technical review and **extensive testing** across different environments to ensure long-term stability.